### PR TITLE
feat: retry on 502

### DIFF
--- a/tools/github/hooks/prerun.sh
+++ b/tools/github/hooks/prerun.sh
@@ -27,7 +27,9 @@ cat <<EOF > warpbuild_body.json
 EOF
 
 # Use wget with retries, retry interval, no certificate check, and exit on failure
-wget --tries=5 --waitretry=2 --retry-connrefused --retry-on-host-error --no-check-certificate --continue --no-verbose \
+wget --tries=5 --waitretry=2 --retry-connrefused \
+  --retry-on-host-error --retry-on-http-error=502 \
+  --no-check-certificate --continue --no-verbose \
   --header="Content-Type: application/json" \
   --header="X-Warpbuild-Scope-Token: $WARPBUILD_SCOPE_TOKEN" \
   -O - --post-file=warpbuild_body.json \


### PR DESCRIPTION
Wget's retry doesn't automatically try on http errors, we need to pass `--retry-on-http-errors=http_error` to retry it for the specific error.