### PR TITLE
Github actions cache clients expect 204 when there is no entry

### DIFF
--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -55,8 +55,13 @@ func GetCacheEntryHandler(c *fiber.Ctx) error {
 	resp, err := GetCache(c.Context(), DockerGHAGetCacheRequest{Keys: keys, Version: version, CacheBackendInfo: CacheBackendInfo{HostURL: getCacheBackendURL(c), AuthToken: getAuthorizationToken(c)}})
 	if err != nil {
 		fmt.Printf("Error getting cache: %v\n", err)
-		// GHA backend expects a 200 response even if the cache is not found. It checks if the cache key is empty.
+		c.Status(204)
+		// GHA backend expects a 204 response if the cache is not found.
 		return c.JSON(DockerGHAGetCacheResponse{CacheKey: "", ArchiveLocation: ""})
+	}
+
+	if resp.ArchiveLocation == "" {
+		c.Status(204)
 	}
 
 	return c.JSON(resp)

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -55,9 +55,8 @@ func GetCacheEntryHandler(c *fiber.Ctx) error {
 	resp, err := GetCache(c.Context(), DockerGHAGetCacheRequest{Keys: keys, Version: version, CacheBackendInfo: CacheBackendInfo{HostURL: getCacheBackendURL(c), AuthToken: getAuthorizationToken(c)}})
 	if err != nil {
 		fmt.Printf("Error getting cache: %v\n", err)
-		c.Status(204)
-		// GHA backend expects a 204 response if the cache is not found.
-		return c.JSON(DockerGHAGetCacheResponse{CacheKey: "", ArchiveLocation: ""})
+		// GHA backend expects a 204 response even if the cache is not found. It checks if the cache key is empty.
+		return c.Status(fiber.StatusNoContent).JSON(DockerGHAGetCacheResponse{CacheKey: "", ArchiveLocation: ""})
 	}
 
 	if resp.ArchiveLocation == "" {


### PR DESCRIPTION
While the official github actions cache client is forgiving, others like opendal are not. Opendal is used by sccache's ghac backend, and currently sccache crashes when it encounters a missing entry, because it does not do the check for archive location being present; instead it checks for the 204 status code.