### PR TITLE
disables internal telemetry of otel collector

### DIFF
--- a/pkg/telemetry/otel-collector-config.tmpl
+++ b/pkg/telemetry/otel-collector-config.tmpl
@@ -46,3 +46,6 @@ service:
       receivers: [hostmetrics]
       processors: [batch]
       exporters: [file]
+  telemetry:
+    metrics:
+      level: none


### PR DESCRIPTION
- By default, port 8888 is used by otel collector to publish its own internal telemetry. This is not needed for us.

Ref: https://opentelemetry.io/docs/collector/internal-telemetry/

GitHub Issue: https://github.com/open-telemetry/opentelemetry-collector/discussions/6547