### PR TITLE
feat: add parent retries to start job call

### DIFF
--- a/tools/github/hooks/prerun.sh
+++ b/tools/github/hooks/prerun.sh
@@ -70,6 +70,7 @@ while [[ max_parent_retries -gt 0 ]]; do
       echo "Retries left: $max_parent_retries"
       rm warpbuild_response
   else
+      echo "Request completed successfully."
       break
   fi
 


### PR DESCRIPTION
## Desc

On API failures we get a non-zero exit code. Adds retries on receiving non-zero exit codes, up to 3 times.

Tool `expr` is invoked for calculating the retries, this is part of GNU coreutils so it's present in all the ubuntu images. https://www.gnu.org/software/coreutils/manual/html_node/expr-invocation.html#expr-invocation