### PR TITLE
fix: incorrect exit_code handling

### DIFF
--- a/tools/github/hooks/prerun.sh
+++ b/tools/github/hooks/prerun.sh
@@ -70,6 +70,7 @@ while [[ max_parent_retries -gt 0 ]]; do
       cat warpbuild_response
       max_parent_retries=$(expr $max_parent_retries - 1)
       echo "Retries left: $max_parent_retries"
+      unset exit_code
       rm warpbuild_response
       sleep $retry_delay_seconds
   else


### PR DESCRIPTION
## Desc

Unset exit_code when it reaches the retry block. Since exit_code is not unset. During failures a non-zero exit code is set, ideally this should be unset when we get a 200 OK response from the server but this does not happen.