### PR TITLE
feat: reduce batch size for metrics data to 30s

### DIFF
--- a/pkg/telemetry/otel-collector-config.tmpl
+++ b/pkg/telemetry/otel-collector-config.tmpl
@@ -119,7 +119,7 @@ processors:
     send_batch_size: 10_000
 
   batch/metrics:
-    timeout: 60s
+    timeout: 30s
     send_batch_size: 10_000_000
 
   # Keep ONLY these 4 metrics in the pipeline


### PR DESCRIPTION
## Desc

The metrics data doesn't show up for small running jobs of <1m. Reduce the batch size to 30s to make sure this data shows up.