### PR TITLE
Benchmark/poc around UDS benefits over TCP loopback for cach…

### DIFF
--- a/pkg/transparent-cache/asur/asur.go
+++ b/pkg/transparent-cache/asur/asur.go
@@ -1079,6 +1079,9 @@ func Start(port int) error {
 		}
 	}()
 
+	// Start UDS listener for small-payload requests (see benchmark: <32KB benefits from UDS)
+	startUDSListener(loggingMiddleware(s))
+
 	return srv.ListenAndServe()
 }
 

--- a/pkg/transparent-cache/asur/uds_unix.go
+++ b/pkg/transparent-cache/asur/uds_unix.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+package asur
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+// UDSSocketPath returns the path to the ASUR Unix Domain Socket.
+// Set ASUR_UDS_PATH environment variable to override the default.
+func UDSSocketPath() string {
+	if p := os.Getenv("ASUR_UDS_PATH"); p != "" {
+		return p
+	}
+	return "/tmp/warpbuild-asur.sock"
+}
+
+// startUDSListener starts an HTTP server on a Unix Domain Socket for small-payload requests.
+// This runs alongside the main TCP listener to give latency/throughput benefits for
+// payloads under 32KB (see benchmark results in pkg/transparent-cache/benchmark/uds_vs_tcp.go).
+func startUDSListener(handler http.Handler) {
+	path := UDSSocketPath()
+	os.Remove(path)
+
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		log.Printf("Warning: Failed to start ASUR UDS listener at %s: %v. Using TCP only.", path, err)
+		return
+	}
+
+	if err := os.Chmod(path, 0666); err != nil {
+		log.Printf("Warning: Failed to chmod ASUR UDS socket: %v", err)
+	}
+
+	log.Printf("ASUR UDS listener started at %s", path)
+
+	udsSrv := &http.Server{
+		Handler:        handler,
+		ReadTimeout:    30 * time.Minute,
+		WriteTimeout:   30 * time.Minute,
+		MaxHeaderBytes: 1 << 20,
+	}
+
+	go func() {
+		if err := udsSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			log.Printf("ASUR UDS server error: %v", err)
+		}
+	}()
+}

--- a/pkg/transparent-cache/asur/uds_windows.go
+++ b/pkg/transparent-cache/asur/uds_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package asur
+
+import (
+	"net/http"
+	"os"
+)
+
+// UDSSocketPath returns the ASUR Unix Domain Socket path.
+// Set ASUR_UDS_PATH environment variable to override the default.
+func UDSSocketPath() string {
+	if p := os.Getenv("ASUR_UDS_PATH"); p != "" {
+		return p
+	}
+	return "/tmp/warpbuild-asur.sock"
+}
+
+// startUDSListener is a no-op on Windows.
+func startUDSListener(handler http.Handler) {}

--- a/pkg/transparent-cache/benchmark/uds_vs_tcp.go
+++ b/pkg/transparent-cache/benchmark/uds_vs_tcp.go
@@ -1,0 +1,271 @@
+//go:build ignore
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"text/tabwriter"
+	"time"
+)
+
+type Metrics struct {
+	rps        float64
+	avgLatency time.Duration
+	mbps       float64
+}
+
+type BenchmarkCase struct {
+	name       string
+	payload    int
+	conns      int
+	total      int
+	downstream time.Duration
+}
+
+type ExperimentResult struct {
+	name       string
+	payload    int
+	conns      int
+	total      int
+	downstream time.Duration
+	tcp        Metrics
+	uds        Metrics
+}
+
+func main() {
+	fmt.Println("======================================")
+	fmt.Println(" Upload Pipeline Benchmark (TCP vs UDS)")
+	fmt.Println("======================================\n")
+
+	tests := []BenchmarkCase{
+		{"Small upload", 1024, 20, 100, 200 * time.Microsecond},
+		{"Medium upload", 4096, 20, 100, 200 * time.Microsecond},
+		{"Large upload", 16384, 20, 100, 200 * time.Microsecond},
+		{"Very large upload", 65536, 20, 100, 200 * time.Microsecond},
+	}
+
+	results := make([]ExperimentResult, 0, len(tests))
+	for _, t := range tests {
+		results = append(results, runExperiment(t))
+	}
+
+	printResultsTable(results)
+}
+
+func runExperiment(test BenchmarkCase) ExperimentResult {
+	tcpLn, _ := startServer("tcp", "127.0.0.1:0", test.downstream)
+	defer tcpLn.Close()
+	tcpAddr := tcpLn.Addr().String()
+
+	udsAddr := fmt.Sprintf("/tmp/upload_%d.sock", time.Now().UnixNano())
+	udsLn, _ := startServer("unix", udsAddr, test.downstream)
+	defer func() {
+		udsLn.Close()
+		os.Remove(udsAddr)
+	}()
+
+	tcp := runClient("tcp", tcpAddr, test.conns, test.total, test.payload)
+	uds := runClient("unix", udsAddr, test.conns, test.total, test.payload)
+
+	return ExperimentResult{
+		name:       test.name,
+		payload:    test.payload,
+		conns:      test.conns,
+		total:      test.total,
+		downstream: test.downstream,
+		tcp:        tcp,
+		uds:        uds,
+	}
+}
+
+func startServer(network, addr string, downstream time.Duration) (net.Listener, error) {
+	if network == "unix" {
+		os.Remove(addr)
+	}
+
+	ln, err := net.Listen(network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handleConn(conn, downstream)
+		}
+	}()
+
+	return ln, nil
+}
+
+func handleConn(conn net.Conn, downstream time.Duration) {
+	defer conn.Close()
+
+	lenBuf := make([]byte, 4)
+
+	for {
+		// Read payload size
+		_, err := io.ReadFull(conn, lenBuf)
+		if err != nil {
+			return
+		}
+		size := binary.BigEndian.Uint32(lenBuf)
+
+		// Read payload
+		payload := make([]byte, size)
+		_, err = io.ReadFull(conn, payload)
+		if err != nil {
+			return
+		}
+
+		// Simulate downstream (S3 upload)
+		if downstream > 0 {
+			time.Sleep(downstream)
+		}
+
+		// Return small metadata response (8 bytes)
+		resp := make([]byte, 8)
+		binary.BigEndian.PutUint64(resp, uint64(size)) // pretend "uploaded size"
+		conn.Write(resp)
+	}
+}
+
+func runClient(network, addr string, conns, total, payload int) Metrics {
+	var wg sync.WaitGroup
+	var totalLatency int64
+
+	perConn := total / conns
+	start := time.Now()
+
+	wg.Add(conns)
+
+	for i := 0; i < conns; i++ {
+		go func() {
+			defer wg.Done()
+
+			conn, err := net.Dial(network, addr)
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+
+			data := make([]byte, payload)
+			lenBuf := make([]byte, 4)
+			resp := make([]byte, 8)
+
+			binary.BigEndian.PutUint32(lenBuf, uint32(payload))
+
+			for j := 0; j < perConn; j++ {
+				t1 := time.Now()
+
+				// send size + payload
+				conn.Write(lenBuf)
+				conn.Write(data)
+
+				// read metadata response
+				io.ReadFull(conn, resp)
+
+				lat := time.Since(t1)
+				atomic.AddInt64(&totalLatency, lat.Nanoseconds())
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	elapsed := time.Since(start)
+	rps := float64(total) / elapsed.Seconds()
+
+	totalBytes := float64(total * payload)
+	mbps := totalBytes / elapsed.Seconds() / (1024 * 1024)
+
+	avgLat := time.Duration(totalLatency / int64(total))
+
+	return Metrics{
+		rps:        rps,
+		avgLatency: avgLat,
+		mbps:       mbps,
+	}
+}
+
+func printResultsTable(results []ExperimentResult) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintln(w, "Test\tPayload\tTCP req/s\tUDS req/s\tThroughput benefit\tTCP latency\tUDS latency\tLatency benefit\tTCP MB/s\tUDS MB/s")
+	for _, result := range results {
+		fmt.Fprintf(
+			w,
+			"%s\t%dB\t%.0f\t%.0f\t%s\t%s\t%s\t%s\t%.2f\t%.2f\n",
+			result.name,
+			result.payload,
+			result.tcp.rps,
+			result.uds.rps,
+			formatPercent(throughputBenefit(result.tcp, result.uds)),
+			result.tcp.avgLatency,
+			result.uds.avgLatency,
+			formatPercent(latencyBenefit(result.tcp, result.uds)),
+			result.tcp.mbps,
+			result.uds.mbps,
+		)
+	}
+
+	w.Flush()
+
+	fmt.Println("\nPositive throughput benefit = UDS higher req/s. Positive latency benefit = UDS lower latency.")
+}
+
+func throughputBenefit(tcp, uds Metrics) float64 {
+	if tcp.rps == 0 {
+		return 0
+	}
+
+	return ((uds.rps - tcp.rps) / tcp.rps) * 100
+}
+
+func latencyBenefit(tcp, uds Metrics) float64 {
+	tcpLatency := tcp.avgLatency.Nanoseconds()
+	if tcpLatency == 0 {
+		return 0
+	}
+
+	return (float64(tcpLatency-uds.avgLatency.Nanoseconds()) / float64(tcpLatency)) * 100
+}
+
+func formatPercent(value float64) string {
+	return fmt.Sprintf("%+.2f%%", value)
+}
+
+// low payload, better UDS benefit
+// if we increase the total requests, the benefits shrink. 
+
+
+// Run 1
+// ======================================
+//  Upload Pipeline Benchmark (TCP vs UDS)
+// ======================================
+
+// Test               Payload  TCP req/s  UDS req/s  Throughput benefit  TCP latency  UDS latency  Latency benefit  TCP MB/s  UDS MB/s
+// Small upload       1024B    28101      44888      +59.74%             523.306µs    382.372µs    +26.93%          27.44     43.84
+// Medium upload      4096B    35191      68695      +95.21%             425.182µs    246.319µs    +42.07%          137.46    268.34
+// Large upload       16384B   26566      40894      +53.93%             623.251µs    391.412µs    +37.20%          415.09    638.96
+// Very large upload  65536B   20199      18365      -9.08%              818.659µs    957.803µs    -17.00%          1262.45   1147.81
+
+// Run 2
+// ======================================
+//  Upload Pipeline Benchmark (TCP vs UDS)
+// ======================================
+
+// Test               Payload  TCP req/s  UDS req/s  Throughput benefit  TCP latency  UDS latency  Latency benefit  TCP MB/s  UDS MB/s
+// Small upload       1024B    29559      56540      +91.28%             522.401µs    291.325µs    +44.23%          28.87     55.21
+// Medium upload      4096B    28551      53164      +86.21%             560.567µs    301.608µs    +46.20%          111.53    207.67
+// Large upload       16384B   28075      35612      +26.84%             570.949µs    406.074µs    +28.88%          438.68    556.44
+// Very large upload  65536B   21731      20282      -6.67%              776.397µs    795.588µs    -2.47%           1358.19   1267.64

--- a/pkg/transparent-cache/oginy/oginy.go
+++ b/pkg/transparent-cache/oginy/oginy.go
@@ -2,6 +2,7 @@ package oginy
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -24,6 +25,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/warpbuilds/warpbuild-agent/pkg/transparent-cache/asur"
 )
 
 // Global logger and mutex for thread-safe file writing
@@ -169,6 +172,25 @@ func (l *loggingRoundTripper) RoundTrip(r *http.Request) (*http.Response, error)
 	}
 
 	return resp, nil
+}
+
+const (
+	asurHost                = "warpbuild.blob.core.windows.net"
+	asurUDSPayloadThreshold = 32 * 1024
+)
+
+type payloadAwareRoundTripper struct {
+	threshold int64
+	tcp       http.RoundTripper
+	uds       http.RoundTripper
+}
+
+func (p *payloadAwareRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	if p.uds != nil && r.ContentLength > 0 && r.ContentLength < p.threshold {
+		return p.uds.RoundTrip(r)
+	}
+
+	return p.tcp.RoundTrip(r)
 }
 
 type proxyEntry struct {
@@ -562,7 +584,7 @@ func Start(port int, derpPort int, asurPort int, certDir string, loggingEnabled 
 		targetURL  string
 	}{
 		{
-			serverName: "warpbuild.blob.core.windows.net",
+			serverName: asurHost,
 			certFile:   filepath.Join(certDir, "warpbuild.crt"),
 			keyFile:    filepath.Join(certDir, "warpbuild.key"),
 			targetURL:  fmt.Sprintf("http://127.0.0.1:%d", asurPort),
@@ -599,6 +621,34 @@ func Start(port int, derpPort int, asurPort int, certDir string, loggingEnabled 
 		DisableCompression:    true, // preserve encodings; avoid cpu
 	}
 
+	asurTransport := http.RoundTripper(tr)
+	if runtime.GOOS != "windows" {
+		udsSocketPath := asur.UDSSocketPath()
+		asurUDSTransport := &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, "unix", udsSocketPath)
+			},
+			ForceAttemptHTTP2:     false,
+			MaxIdleConns:          1024,
+			MaxIdleConnsPerHost:   512,
+			MaxConnsPerHost:       0,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 0,
+			DisableCompression:    true,
+		}
+
+		asurTransport = &payloadAwareRoundTripper{
+			threshold: int64(asurUDSPayloadThreshold),
+			tcp:       tr,
+			uds:       asurUDSTransport,
+		}
+
+		log.Printf("ASUR adaptive routing enabled: UDS for payloads < %d bytes via %s; TCP otherwise", asurUDSPayloadThreshold, udsSocketPath)
+	} else {
+		log.Printf("ASUR adaptive routing disabled on Windows; using TCP only")
+	}
+
 	mp := &muxProxy{byHost: make(map[string]*proxyEntry)}
 
 	for _, s := range servers {
@@ -613,8 +663,12 @@ func Start(port int, derpPort int, asurPort int, certDir string, loggingEnabled 
 
 		// Create proxy with logging transport
 		rp := httputil.NewSingleHostReverseProxy(u)
+		backendTransport := http.RoundTripper(tr)
+		if s.serverName == asurHost {
+			backendTransport = asurTransport
+		}
 		loggingTransport := &loggingRoundTripper{
-			transport: tr,
+			transport: backendTransport,
 			name:      fmt.Sprintf("LOCAL:%s→%s", s.serverName, s.targetURL),
 		}
 		rp.Transport = loggingTransport


### PR DESCRIPTION
<h3><strong><span>What</span></strong></h3><p class="isSelectedEnd"><span>Introduce adaptive transport between Oginy → ASUR (can be extended to Oginy > Derp as well):</span></p><ul data-spread="false"><li><p class="isSelectedEnd"><strong><span>UDS</span></strong><span> for small payloads</span></p></li><li><p class="isSelectedEnd"><strong><span>TCP loopback</span></strong><span> for large payloads</span></p></li></ul><div contenteditable="false"><hr></div><h3><strong><span>Why</span></strong></h3><p class="isSelectedEnd"><span>Benchmarks show UDS helps only when IPC dominates (small payloads).</span><br><span>For larger uploads, memory + downstream work dominate, and TCP performs equal or better.</span></p><div contenteditable="false"><hr></div><h3><strong><span>Benchmark Summary (M3 Pro, macOS)</span></strong></h3>

## 📊 Benchmark Results: TCP vs UDS (Oginy → ASUR)

### Run 1

| Test               | Payload | TCP req/s | UDS req/s | Throughput Δ | TCP Latency | UDS Latency | Latency Δ | TCP MB/s | UDS MB/s |
|--------------------|--------|----------|----------|--------------|-------------|-------------|-----------|----------|----------|
| Small upload       | 1024B  | 28,101   | 44,888   | **+59.74%**  | 523.306µs   | 382.372µs   | **+26.93%** | 27.44   | 43.84   |
| Medium upload      | 4096B  | 35,191   | 68,695   | **+95.21%**  | 425.182µs   | 246.319µs   | **+42.07%** | 137.46  | 268.34  |
| Large upload       | 16384B | 26,566   | 40,894   | **+53.93%**  | 623.251µs   | 391.412µs   | **+37.20%** | 415.09  | 638.96  |
| Very large upload  | 65536B | 20,199   | 18,365   | **-9.08%**   | 818.659µs   | 957.803µs   | **-17.00%** | 1262.45 | 1147.81 |

---

### Run 2 (Repeatability)

| Test               | Payload | TCP req/s | UDS req/s | Throughput Δ | TCP Latency | UDS Latency | Latency Δ | TCP MB/s | UDS MB/s |
|--------------------|--------|----------|----------|--------------|-------------|-------------|-----------|----------|----------|
| Small upload       | 1024B  | 29,559   | 56,540   | **+91.28%**  | 522.401µs   | 291.325µs   | **+44.23%** | 28.87   | 55.21   |
| Medium upload      | 4096B  | 28,551   | 53,164   | **+86.21%**  | 560.567µs   | 301.608µs   | **+46.20%** | 111.53  | 207.67  |
| Large upload       | 16384B | 28,075   | 35,612   | **+26.84%**  | 570.949µs   | 406.074µs   | **+28.88%** | 438.68  | 556.44  |
| Very large upload  | 65536B | 21,731   | 20,282   | **-6.67%**   | 776.397µs   | 795.588µs   | **-2.47%**  | 1358.19 | 1267.64 |

---

### 🧠 Summary

- **UDS significantly improves performance for small/medium payloads**
  - Up to **~2x throughput**
  - ~25–45% lower latency

- **Benefits reduce as payload increases**
  - Memory + downstream costs dominate

- **UDS regresses for very large payloads (64KB)**
  - ~5–10% lower throughput than TCP

👉 Conclusion:  
Use **UDS for small payloads**, **TCP for large uploads**



Note: 
Resources Referred to 
https://rednafi.com/misc/tinkering-with-unix-domain-socket/
https://github.com/MagicStack/uvloop/issues/345
https://nodevibe.substack.com/p/the-nodejs-developers-guide-to-unix