### PR TITLE
tailscale status device list noise removal

### DIFF
--- a/tools/addons/tailscale_setup_linux.sh
+++ b/tools/addons/tailscale_setup_linux.sh
@@ -37,7 +37,7 @@ while [ $login_elapsed -lt $login_timeout ]; do
     --id-token="${WARPBUILD_ADDON_TS_OIDC_TOKEN}" \
     ${WARPBUILD_ADDON_TS_ARGS:-} 2>&1; then
     echo "[tailscale-addon] Tailscale is connected"
-    sudo tailscale status || true
+    sudo tailscale status --peers=false || true
     echo "[tailscale-addon] Tailscale setup complete"
     exit 0
   fi

--- a/tools/addons/tailscale_setup_macos.sh
+++ b/tools/addons/tailscale_setup_macos.sh
@@ -27,7 +27,7 @@ while [ $login_elapsed -lt $login_timeout ]; do
     --id-token="${WARPBUILD_ADDON_TS_OIDC_TOKEN}" \
     ${WARPBUILD_ADDON_TS_ARGS:-} 2>&1; then
     echo "[tailscale-addon] Tailscale is connected"
-    sudo tailscale status || true
+    sudo tailscale status --peers=false || true
     echo "[tailscale-addon] Tailscale setup complete"
     exit 0
   fi

--- a/tools/addons/tailscale_setup_windows.ps1
+++ b/tools/addons/tailscale_setup_windows.ps1
@@ -47,7 +47,7 @@ while ($loginElapsed -lt $loginTimeout) {
 
     if ($upExit -eq 0) {
         Write-Host "[tailscale-addon] Tailscale is connected"
-        & $TS_BIN status 2>&1 | ForEach-Object { Write-Host "[tailscale-addon]   $_" }
+        & $TS_BIN status --peers=false 2>&1 | ForEach-Object { Write-Host "[tailscale-addon]   $_" }
         Write-Host "[tailscale-addon] Tailscale setup complete"
         exit 0
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes post-login logging by suppressing peer listings in `tailscale status`, with no changes to authentication or connection behavior.
> 
> **Overview**
> After a successful `tailscale up`, the Linux, macOS, and Windows setup scripts now call `tailscale status --peers=false` instead of `tailscale status` to avoid emitting the full device/peer list in logs.
> 
> No connection flow or retry behavior changes; this is a logging/output reduction only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669f0bbf070245223c2a4cd66d312bfffaffebfc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->