### PR TITLE
name pattern prefix

### DIFF
--- a/tools/addons/tailscale_setup_linux.sh
+++ b/tools/addons/tailscale_setup_linux.sh
@@ -32,7 +32,7 @@ login_timeout=30
 login_elapsed=0
 while [ $login_elapsed -lt $login_timeout ]; do
   if sudo tailscale up \
-    --hostname="warpbuild-${WARPBUILD_ADDON_TS_RUNNER_INSTANCE_ID}" \
+    --hostname="${WARPBUILD_ADDON_TS_RUNNER_INSTANCE_ID}" \
     --client-id="${WARPBUILD_ADDON_TS_CLIENT_ID}" \
     --id-token="${WARPBUILD_ADDON_TS_OIDC_TOKEN}" \
     ${WARPBUILD_ADDON_TS_ARGS:-} 2>&1; then

--- a/tools/addons/tailscale_setup_macos.sh
+++ b/tools/addons/tailscale_setup_macos.sh
@@ -22,7 +22,7 @@ login_timeout=30
 login_elapsed=0
 while [ $login_elapsed -lt $login_timeout ]; do
   if sudo tailscale up \
-    --hostname="warpbuild-${WARPBUILD_ADDON_TS_RUNNER_INSTANCE_ID}" \
+    --hostname="${WARPBUILD_ADDON_TS_RUNNER_INSTANCE_ID}" \
     --client-id="${WARPBUILD_ADDON_TS_CLIENT_ID}" \
     --id-token="${WARPBUILD_ADDON_TS_OIDC_TOKEN}" \
     ${WARPBUILD_ADDON_TS_ARGS:-} 2>&1; then

--- a/tools/addons/tailscale_setup_windows.ps1
+++ b/tools/addons/tailscale_setup_windows.ps1
@@ -33,7 +33,7 @@ $loginElapsed = 0
 while ($loginElapsed -lt $loginTimeout) {
     $tsArgs = @(
         "up",
-        "--hostname=warpbuild-$env:WARPBUILD_ADDON_TS_RUNNER_INSTANCE_ID",
+        "--hostname=$env:WARPBUILD_ADDON_TS_RUNNER_INSTANCE_ID",
         "--client-id=$env:WARPBUILD_ADDON_TS_CLIENT_ID",
         "--id-token=$env:WARPBUILD_ADDON_TS_OIDC_TOKEN"
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes the `tailscale up --hostname` value in setup scripts; potential impact is limited to how nodes appear/are matched in Tailscale ACLs or admin UI.
> 
> **Overview**
> Removes the hardcoded `warpbuild-` prefix from the `--hostname` passed to `tailscale up` across the Linux (`tailscale_setup_linux.sh`), macOS (`tailscale_setup_macos.sh`), and Windows (`tailscale_setup_windows.ps1`) addon setup scripts, so the hostname is now exactly `WARPBUILD_ADDON_TS_RUNNER_INSTANCE_ID`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3c1bbb9abc926bac4a9c5144500462f8bc5443f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->