### PR TITLE
feat: add byoc pre hook script

### DIFF
--- a/.github/workflows/release-testing.yaml
+++ b/.github/workflows/release-testing.yaml
@@ -5,8 +5,7 @@ on:
   push:
     branches:
       - main
-      - feat/macos-init-commands
-      - feat/tailscale-oidc-addon
+      - ah-byoc-pre-hook-script
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.WB_PACKAGES_DEV_R2_ACCESS_KEY_ID }}

--- a/tools/github/hooks/prerun.ps1
+++ b/tools/github/hooks/prerun.ps1
@@ -141,18 +141,41 @@ if ($response -and $response.Content) {
     }
 }
 
+# BYOC substitute to ACTIONS_RUNNER_HOOK_JOB_STARTED
+# See: https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts
 $byocPreHook = $env:WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED
 if ($byocPreHook) {
     Write-Host "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byocPreHook"
+
+    if (-not [System.IO.Path]::IsPathRooted($byocPreHook)) {
+        Write-Host "User-defined pre-hook script path must be absolute: $byocPreHook"
+        exit 1
+    }
+
     if (-not (Test-Path -Path $byocPreHook -PathType Leaf)) {
         Write-Host "User-defined pre-hook script not found at: $byocPreHook"
         exit 1
     }
+
     Write-Host "Executing user-defined pre-hook"
-    if ($byocPreHook -match '\.ps1$') {
-        & powershell -ExecutionPolicy Bypass -File $byocPreHook
+    $hookExt = [System.IO.Path]::GetExtension($byocPreHook).ToLowerInvariant()
+    if ($hookExt -eq '.ps1') {
+        $hookCommand = ". '$byocPreHook'"
+        if (Get-Command pwsh -ErrorAction SilentlyContinue) {
+            & pwsh -command $hookCommand
+        } else {
+            & powershell -command $hookCommand
+        }
+    } elseif ($hookExt -eq '.sh') {
+        if (Get-Command bash -ErrorAction SilentlyContinue) {
+            & bash --noprofile --norc -e -o pipefail $byocPreHook
+        } else {
+            Write-Host "Cannot run .sh pre-hook: bash is not installed."
+            exit 1
+        }
     } else {
-        & cmd.exe /c $byocPreHook
+        Write-Host "User-defined pre-hook script has an unsupported extension. Supported: .sh, .ps1"
+        exit 1
     }
     $hookExitCode = $LASTEXITCODE
     if ($hookExitCode -ne 0) {

--- a/tools/github/hooks/prerun.ps1
+++ b/tools/github/hooks/prerun.ps1
@@ -145,7 +145,7 @@ if ($response -and $response.Content) {
 # See: https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts
 $byocPreHook = $env:WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED
 if ($byocPreHook) {
-    Write-Host "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byocPreHook"
+    Write-Host "`nWARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED is set to: $byocPreHook"
 
     if (-not [System.IO.Path]::IsPathRooted($byocPreHook)) {
         Write-Host "User-defined pre-hook script path must be absolute: $byocPreHook"
@@ -177,10 +177,8 @@ if ($byocPreHook) {
         Write-Host "User-defined pre-hook script has an unsupported extension. Supported: .sh, .ps1"
         exit 1
     }
-    $hookExitCode = $LASTEXITCODE
-    if ($hookExitCode -ne 0) {
-        Write-Host "User-defined pre-hook exited with non-zero status: $hookExitCode"
-        exit $hookExitCode
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
     }
     Write-Host "User-defined pre-hook completed successfully."
 }

--- a/tools/github/hooks/prerun.ps1
+++ b/tools/github/hooks/prerun.ps1
@@ -141,4 +141,25 @@ if ($response -and $response.Content) {
     }
 }
 
+$byocPreHook = $env:WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED
+if ($byocPreHook) {
+    Write-Host "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byocPreHook"
+    if (-not (Test-Path -Path $byocPreHook -PathType Leaf)) {
+        Write-Host "User-defined pre-hook script not found at: $byocPreHook"
+        exit 1
+    }
+    Write-Host "Executing user-defined pre-hook"
+    if ($byocPreHook -match '\.ps1$') {
+        & powershell -ExecutionPolicy Bypass -File $byocPreHook
+    } else {
+        & cmd.exe /c $byocPreHook
+    }
+    $hookExitCode = $LASTEXITCODE
+    if ($hookExitCode -ne 0) {
+        Write-Host "User-defined pre-hook exited with non-zero status: $hookExitCode"
+        exit $hookExitCode
+    }
+    Write-Host "User-defined pre-hook completed successfully."
+}
+
 Write-Host "`nPrehook for WarpBuild runner instance '$env:RUNNER_NAME' completed successfully."

--- a/tools/github/hooks/prerun.ps1
+++ b/tools/github/hooks/prerun.ps1
@@ -141,6 +141,9 @@ if ($response -and $response.Content) {
     }
 }
 
+Write-Host "Checking for user-defined pre-hook script..."
+$hookCheckTimer = [System.Diagnostics.Stopwatch]::StartNew()
+
 $byocPreHook = $env:WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED
 if ($byocPreHook) {
     Write-Host "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byocPreHook"
@@ -161,5 +164,8 @@ if ($byocPreHook) {
     }
     Write-Host "User-defined pre-hook completed successfully."
 }
+
+$hookCheckTimer.Stop()
+Write-Host ("Done checking. Time taken: {0:N0}μs" -f ($hookCheckTimer.Elapsed.TotalMilliseconds * 1000))
 
 Write-Host "`nPrehook for WarpBuild runner instance '$env:RUNNER_NAME' completed successfully."

--- a/tools/github/hooks/prerun.ps1
+++ b/tools/github/hooks/prerun.ps1
@@ -141,9 +141,6 @@ if ($response -and $response.Content) {
     }
 }
 
-Write-Host "Checking for user-defined pre-hook script..."
-$hookCheckTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
 $byocPreHook = $env:WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED
 if ($byocPreHook) {
     Write-Host "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byocPreHook"
@@ -164,8 +161,5 @@ if ($byocPreHook) {
     }
     Write-Host "User-defined pre-hook completed successfully."
 }
-
-$hookCheckTimer.Stop()
-Write-Host ("Done checking. Time taken: {0:N0}μs" -f ($hookCheckTimer.Elapsed.TotalMilliseconds * 1000))
 
 Write-Host "`nPrehook for WarpBuild runner instance '$env:RUNNER_NAME' completed successfully."

--- a/tools/github/hooks/prerun.sh
+++ b/tools/github/hooks/prerun.sh
@@ -128,8 +128,6 @@ fi
 
 rm -f warpbuild_response
 
-echo -e "\nPrehook for WarpBuild runner instance '$RUNNER_NAME' completed successfully."
-
 byoc_pre_hook="$WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED"
 if [ -n "$byoc_pre_hook" ]; then
     echo "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byoc_pre_hook"
@@ -146,3 +144,5 @@ if [ -n "$byoc_pre_hook" ]; then
         echo "User-defined pre-hook script is not a valid executable file. Skipping."
     fi
 fi
+
+echo -e "\nPrehook for WarpBuild runner instance '$RUNNER_NAME' completed successfully."

--- a/tools/github/hooks/prerun.sh
+++ b/tools/github/hooks/prerun.sh
@@ -132,7 +132,7 @@ rm -f warpbuild_response
 # See: https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts
 byoc_pre_hook="$WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED"
 if [ -n "$byoc_pre_hook" ]; then
-    echo "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byoc_pre_hook"
+    echo -e "\nWARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED is set to: $byoc_pre_hook"
 
     if [ "${byoc_pre_hook:0:1}" != "/" ]; then
         echo "User-defined pre-hook script path must be absolute: $byoc_pre_hook"
@@ -162,11 +162,6 @@ if [ -n "$byoc_pre_hook" ]; then
     else
         echo "User-defined pre-hook script has an unsupported extension. Supported: .sh, .ps1"
         exit 1
-    fi
-    hook_exit_code=$?
-    if [ $hook_exit_code -ne 0 ]; then
-        echo "User-defined pre-hook exited with non-zero status: $hook_exit_code"
-        exit $hook_exit_code
     fi
     echo "User-defined pre-hook completed successfully."
 fi

--- a/tools/github/hooks/prerun.sh
+++ b/tools/github/hooks/prerun.sh
@@ -129,3 +129,20 @@ fi
 rm -f warpbuild_response
 
 echo -e "\nPrehook for WarpBuild runner instance '$RUNNER_NAME' completed successfully."
+
+byoc_pre_hook="$WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED"
+if [ -n "$byoc_pre_hook" ]; then
+    echo "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byoc_pre_hook"
+    if [ -f "$byoc_pre_hook" ] && [ -x "$byoc_pre_hook" ]; then
+        echo "Executing user-defined pre-hook"
+        "$byoc_pre_hook"
+        hook_exit_code=$?
+        if [ $hook_exit_code -ne 0 ]; then
+            echo "User-defined pre-hook exited with non-zero status: $hook_exit_code"
+            exit $hook_exit_code
+        fi
+        echo "User-defined pre-hook completed successfully."
+    else
+        echo "User-defined pre-hook script is not a valid executable file. Skipping."
+    fi
+fi

--- a/tools/github/hooks/prerun.sh
+++ b/tools/github/hooks/prerun.sh
@@ -128,20 +128,41 @@ fi
 
 rm -f warpbuild_response
 
+# BYOC substitute to ACTIONS_RUNNER_HOOK_JOB_STARTED
+# See: https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts
 byoc_pre_hook="$WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED"
 if [ -n "$byoc_pre_hook" ]; then
     echo "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byoc_pre_hook"
+
+    if [ "${byoc_pre_hook:0:1}" != "/" ]; then
+        echo "User-defined pre-hook script path must be absolute: $byoc_pre_hook"
+        exit 1
+    fi
+
     if [ ! -f "$byoc_pre_hook" ]; then
         echo "User-defined pre-hook script not found at: $byoc_pre_hook"
         exit 1
     fi
-    if [ ! -x "$byoc_pre_hook" ]; then
-        echo "User-defined pre-hook script is not executable: $byoc_pre_hook"
-        echo "Run 'chmod +x $byoc_pre_hook' when building your image."
+
+    echo "Executing user-defined pre-hook"
+    hook_ext="${byoc_pre_hook##*.}"
+    if [ "$hook_ext" = "sh" ]; then
+        if command -v bash >/dev/null 2>&1; then
+            bash --noprofile --norc -e -o pipefail "$byoc_pre_hook"
+        else
+            sh -e "$byoc_pre_hook"
+        fi
+    elif [ "$hook_ext" = "ps1" ]; then
+        if command -v pwsh >/dev/null 2>&1; then
+            pwsh -command ". '$byoc_pre_hook'"
+        else
+            echo "Cannot run .ps1 pre-hook: pwsh is not installed."
+            exit 1
+        fi
+    else
+        echo "User-defined pre-hook script has an unsupported extension. Supported: .sh, .ps1"
         exit 1
     fi
-    echo "Executing user-defined pre-hook"
-    "$byoc_pre_hook"
     hook_exit_code=$?
     if [ $hook_exit_code -ne 0 ]; then
         echo "User-defined pre-hook exited with non-zero status: $hook_exit_code"

--- a/tools/github/hooks/prerun.sh
+++ b/tools/github/hooks/prerun.sh
@@ -131,18 +131,23 @@ rm -f warpbuild_response
 byoc_pre_hook="$WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED"
 if [ -n "$byoc_pre_hook" ]; then
     echo "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byoc_pre_hook"
-    if [ -f "$byoc_pre_hook" ] && [ -x "$byoc_pre_hook" ]; then
-        echo "Executing user-defined pre-hook"
-        "$byoc_pre_hook"
-        hook_exit_code=$?
-        if [ $hook_exit_code -ne 0 ]; then
-            echo "User-defined pre-hook exited with non-zero status: $hook_exit_code"
-            exit $hook_exit_code
-        fi
-        echo "User-defined pre-hook completed successfully."
-    else
-        echo "User-defined pre-hook script is not a valid executable file. Skipping."
+    if [ ! -f "$byoc_pre_hook" ]; then
+        echo "User-defined pre-hook script not found at: $byoc_pre_hook"
+        exit 1
     fi
+    if [ ! -x "$byoc_pre_hook" ]; then
+        echo "User-defined pre-hook script is not executable: $byoc_pre_hook"
+        echo "Run 'chmod +x $byoc_pre_hook' when building your image."
+        exit 1
+    fi
+    echo "Executing user-defined pre-hook"
+    "$byoc_pre_hook"
+    hook_exit_code=$?
+    if [ $hook_exit_code -ne 0 ]; then
+        echo "User-defined pre-hook exited with non-zero status: $hook_exit_code"
+        exit $hook_exit_code
+    fi
+    echo "User-defined pre-hook completed successfully."
 fi
 
 echo -e "\nPrehook for WarpBuild runner instance '$RUNNER_NAME' completed successfully."

--- a/tools/github/hooks/prerun.sh
+++ b/tools/github/hooks/prerun.sh
@@ -128,9 +128,6 @@ fi
 
 rm -f warpbuild_response
 
-echo "Checking for user-defined pre-hook script..."
-hook_check_start_ns=$(date +%s%N)
-
 byoc_pre_hook="$WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED"
 if [ -n "$byoc_pre_hook" ]; then
     echo "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byoc_pre_hook"
@@ -152,7 +149,5 @@ if [ -n "$byoc_pre_hook" ]; then
     fi
     echo "User-defined pre-hook completed successfully."
 fi
-
-echo "Done checking. Time taken: $(( ($(date +%s%N) - hook_check_start_ns) / 1000 ))μs"
 
 echo -e "\nPrehook for WarpBuild runner instance '$RUNNER_NAME' completed successfully."

--- a/tools/github/hooks/prerun.sh
+++ b/tools/github/hooks/prerun.sh
@@ -128,6 +128,9 @@ fi
 
 rm -f warpbuild_response
 
+echo "Checking for user-defined pre-hook script..."
+hook_check_start_ns=$(date +%s%N)
+
 byoc_pre_hook="$WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED"
 if [ -n "$byoc_pre_hook" ]; then
     echo "Found user-defined pre-hook script (WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED): $byoc_pre_hook"
@@ -149,5 +152,7 @@ if [ -n "$byoc_pre_hook" ]; then
     fi
     echo "User-defined pre-hook completed successfully."
 fi
+
+echo "Done checking. Time taken: $(( ($(date +%s%N) - hook_check_start_ns) / 1000 ))μs"
 
 echo -e "\nPrehook for WarpBuild runner instance '$RUNNER_NAME' completed successfully."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Executes a user-supplied script on runner startup, which can affect job reliability and expands the surface for misconfiguration or unintended command execution if the environment variable is set incorrectly.
> 
> **Overview**
> Adds support for an optional BYOC pre-hook in `tools/github/hooks/prerun.sh` via `WARPBUILD_ACTIONS_RUNNER_HOOK_JOB_STARTED`.
> 
> If the variable points to an executable file, the script is run after the WarpBuild prehook/addon setup steps; non-zero exit codes now fail the prehook and stop the runner flow, while invalid paths are logged and skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09f24706a9b792f4ffd0a9a1e83d1144a8be05aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->