### PR TITLE
Capture Windows cloud-init log (C:\debuginit.txt) in telemetry

### DIFF
--- a/pkg/telemetry/otel-collector-config.tmpl
+++ b/pkg/telemetry/otel-collector-config.tmpl
@@ -25,6 +25,19 @@ receivers:
     include_file_path: true
     poll_interval: 20s
 
+  # Cloud-init log; written fully before the collector starts, so read from the
+  # beginning. The path may not exist on all images — filelog just matches nothing.
+  filelog/cloudinit:
+    include:
+      - 'C:\debuginit.txt'
+    start_at: beginning
+    max_log_size: 200KiB
+    include_file_name: true
+    include_file_path: true
+    poll_interval: 60s
+    attributes:
+      log.type: cloud_init
+
   # GitHub Actions job logs and diagnostic logs
   filelog/gha_logs:
     include:
@@ -364,7 +377,7 @@ service:
       level: none
   pipelines:
     logs:
-      receivers: [{{- if eq .OS "windows"}}windowseventlog/application, windowseventlog/security, filelog/services{{- else }}filelog{{- end}}]
+      receivers: [{{- if eq .OS "windows"}}windowseventlog/application, windowseventlog/security, filelog/services, filelog/cloudinit{{- else }}filelog{{- end}}]
       processors: [batch/logs]
       exporters: [otlphttp]
     logs/gha_logs:


### PR DESCRIPTION
## Why

While debugging the SonarSource rate-limit incident (runners stuck ALLOCATED because the job-started prehook never fires on their Windows BYOC runners), the investigation dead-ended: the cloud-init phase writes `settings.json` (including `ACTIONS_RUNNER_HOOK_JOB_STARTED`) and logs every step to `C:\debuginit.txt` — but that file is not shipped by the telemetry collector, so we cannot see whether the config write or the setup scripts (`020_setup_warp_agent.vm.ps1`) succeeded on customer VMs.

## What

- New `filelog/cloudinit` receiver (Windows only) tailing `C:\debuginit.txt`, wired into the `logs` pipeline with `log.type: cloud_init`.
- `start_at: beginning` — cloud-init completes before the collector service starts, so `end` would capture nothing.
- Optional by construction: filelog with a non-existent path simply matches nothing; images without the file are unaffected.

Verified the template renders to valid YAML for both `windows` and `linux`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYUvqHtPgFTcXebxgvadxn